### PR TITLE
add ssl cert to bundle

### DIFF
--- a/app/api/Dockerfile
+++ b/app/api/Dockerfile
@@ -13,6 +13,18 @@ RUN mv mc /usr/local/bin/mc
 
 COPY ./subsetter /subsetter
 
+# https://www.digicert.com/kb/digicert-root-certificates.htm
+# Get the .pem file from digicert and add it to the bundle used by certifi
+# Could also use the REQUESTS_CA_BUNDLE environment variable to point to the .pem file
+# This was needed beacause the certifi release 
+# 2024.02.02 https://github.com/certifi/python-certifi/releases/tag/2024.02.02
+# does not include the GeoTrust TLS RSA CA G1 certificate at the time of this writing
+# More info: https://requests.readthedocs.io/en/latest/user/advanced/#ca-certificates
+RUN apt-get update && apt-get install -y wget && apt-get install -y ca-certificates
+RUN wget -O /usr/lib/ssl/certs/GeoTrustTLSRSACAG1.crt.pem https://cacerts.digicert.com/GeoTrustTLSRSACAG1.crt.pem && \
+    update-ca-certificates && \
+    cat /usr/lib/ssl/certs/GeoTrustTLSRSACAG1.crt.pem >> $(python -c "import requests; print(requests.certs.where())")
+
 ENV PYTHONPATH "/subsetter/:${PYTHONPATH}"
 
 EXPOSE 8000


### PR DESCRIPTION
This commit adds the GeoTrustTLSRSACAG1 certificate to the certifi bundle used by the application. The certificate is obtained from digicert and is necessary because the current certifi release (2024.02.02) does not include the GeoTrust TLS RSA CA G1 certificate. The certificate is downloaded using wget and added to the bundle. The update-ca-certificates command is then used to update the certificate store. Finally, the path to the certificate is appended to the certifi bundle using the requests.certs.where() function.

This change ensures that the application can establish secure connections with servers that use the GeoTrustTLSRSACAG1 certificate.